### PR TITLE
Add vite directory to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,25 +2,18 @@
 logs
 *.log
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-lerna-debug.log*
 
 node_modules
 dist
 dist-ssr
 *.local
+.env
 
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
 .idea
 .DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
 
-.env
+# Vite directories
+.vite


### PR DESCRIPTION
- Add `.vite` to gitignore and remove unnecessary files/folders from gitignore that were auto-added by vite when the project was created